### PR TITLE
Updated TransactionHistory to only require the accountID

### DIFF
--- a/api/src/main/java/com/beanbank/api/controller/TransactionController.java
+++ b/api/src/main/java/com/beanbank/api/controller/TransactionController.java
@@ -23,16 +23,9 @@ public class TransactionController {
         return transactionService.makeTransaction(transaction);
     }
 
-    @RequestMapping(value = "/transaction/{accountID}", method = RequestMethod.GET)
-    public List<Transaction> getTransactions(@PathVariable(name = "accountID") int accountID) {
-        return transactionService.getTransactionsForAccount(accountID);
-    }
-
-    @RequestMapping(value = "/transaction/history/{senderID}/{receiverID}", method = RequestMethod.GET)
+    @RequestMapping(value = "/transaction/history/{accountID}", method = RequestMethod.GET)
     public List<Map<String, Object>> getHistory(
-            @PathVariable(name = "senderID") int senderID,
-            @PathVariable(name = "receiverID") int receiverID
-    ){
-        return transactionService.getHistory(senderID, receiverID);
+            @PathVariable(name = "accountID") int accountID) {
+        return transactionService.getHistory(accountID);
     }
 }

--- a/api/src/main/java/com/beanbank/api/repository/TransactionRepository.java
+++ b/api/src/main/java/com/beanbank/api/repository/TransactionRepository.java
@@ -11,19 +11,16 @@ import java.util.List;
 
 @Repository
 public interface TransactionRepository extends JpaRepository<Transaction, Integer> {
-    List<Transaction> findBySenderIDOrReceiverID(int senderID, int receiverID);
-
-    @Query("select " +
-            "   t.transactionID, t.senderID, us.username," +
-            "   t.receiverID, ur.username, tt.transactionTypeName," +
-            "   t.transactionAmount, t.transactionTimestamp " +
-            "from Transaction t" +
-            "    inner join User us on t.senderID = us.userID" +
-            "    inner join User ur on t.receiverID = ur.userID" +
-            "    inner join TransactionsType tt on tt.transactionTypeID = t.transactionTypeID " +
-            "where " +
-            "   t.senderID = :senderID or " +
-            "   t.receiverID = :recieverID")
-    List<Object[]> transactionDetails(@Param("senderID") int senderID,
-                                      @Param("recieverID") int recieverID);
+        @Query("select " +
+                        "   t.transactionID, t.senderID, us.username," +
+                        "   t.receiverID, ur.username, tt.transactionTypeName," +
+                        "   t.transactionAmount, t.transactionTimestamp " +
+                        "from Transaction t" +
+                        "    inner join User us on t.senderID = us.userID" +
+                        "    inner join User ur on t.receiverID = ur.userID" +
+                        "    inner join TransactionsType tt on tt.transactionTypeID = t.transactionTypeID " +
+                        "where " +
+                        "   t.senderID = :accountID or " +
+                        "   t.receiverID = :accountID")
+        List<Object[]> transactionDetails(@Param("accountID") int accountID);
 }

--- a/api/src/main/java/com/beanbank/api/service/TransactionService.java
+++ b/api/src/main/java/com/beanbank/api/service/TransactionService.java
@@ -104,12 +104,8 @@ public class TransactionService {
         return transactionRepository.save(transaction);
     }
 
-    public List<Transaction> getTransactionsForAccount(int accountID) {
-        return transactionRepository.findBySenderIDOrReceiverID(accountID, accountID);
-    }
-
-    public List<Map<String, Object>> getHistory(int senderID, int receiverID) {
-        List<Object[]> transactionDetails = transactionRepository.transactionDetails(senderID, receiverID);
+    public List<Map<String, Object>> getHistory(int accountID) {
+        List<Object[]> transactionDetails = transactionRepository.transactionDetails(accountID);
         List<Map<String, Object>> formattedDetails = new ArrayList<>();
 
         for (Object[] row : transactionDetails) {

--- a/postman/Transaction/Transaction.json
+++ b/postman/Transaction/Transaction.json
@@ -36,39 +36,6 @@
 			"response": []
 		},
 		{
-			"name": "ViewTransactions",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"method": "GET",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"SenderID\": 1,\r\n    \"ReceiverID\": 2,\r\n    \"TransactionTypeID\": 1,\r\n    \"TransactionAmount\": 300,\r\n    \"TransactionTimestamp\": \"2024-03-09\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/api/transaction/1",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"api",
-						"transaction",
-						"1"
-					]
-				}
-			},
-			"response": []
-		},
-		{
 			"name": "Transaction History",
 			"protocolProfileBehavior": {
 				"disableBodyPruning": true
@@ -86,7 +53,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:8080/api/transaction/history/1/1",
+					"raw": "http://localhost:8080/api/transaction/history/1",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -96,7 +63,6 @@
 						"api",
 						"transaction",
 						"history",
-						"1",
 						"1"
 					]
 				}


### PR DESCRIPTION
Account history now only requires the account ID for transaction history instead of sender and receiver.